### PR TITLE
Fix index heading typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 </head>
 
 <body>
-    <h1 class="title">Microservices examle</h1>
+    <h1 class="title">Microservices example</h1>
     <div class="columns">
         <section class="column">
             <div class="container-if">


### PR DESCRIPTION
## Summary
- fix the heading typo in `index.html`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685862e57e708332825a3a8c4bb48a83